### PR TITLE
add option to ignore DJANGO_SETTINGS_MODULE and use all apps available from virtualenv or sys.modules

### DIFF
--- a/staticfiles/management/base.py
+++ b/staticfiles/management/base.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from optparse import make_option
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand, CommandError
@@ -46,11 +47,18 @@ class BaseOptionalAppCommand(BaseCommand):
     def handle(self, *app_labels, **options):
         from django.db import models
         # Get all the apps, checking for common errors.
-        try:
-            all_apps = models.get_apps()
-        except (ImproperlyConfigured, ImportError), e:
-            raise CommandError("%s. Are you sure your INSTALLED_APPS setting "
-                               "is correct?" % e)
+        if options.get('use_virtualenv'):
+            all_apps = []
+            for k,v in sys.modules.iteritems():
+                if k.split(".")[-1] == "models":
+                    all_apps.append(v)
+        else:
+            try:
+                all_apps = models.get_apps()
+            except (ImproperlyConfigured, ImportError), e:
+                raise CommandError("%s. Are you sure your INSTALLED_APPS setting "
+                                   "is correct?" % e)
+
         # Build the app_list.
         app_list = []
         used = 0

--- a/staticfiles/management/commands/build_static.py
+++ b/staticfiles/management/commands/build_static.py
@@ -43,6 +43,9 @@ class Command(OptionalAppCommand):
             dest='use_default_ignore_patterns', default=True,
             help="Don't ignore the common private glob-style patterns 'CVS', "
                 "'.*' and '*~'."),
+        make_option('--use-virtualenv', action='store_true',
+            dest='use_virtualenv', default=False,
+            help="Use all Django apps currently available on PYTHONPATH (from virtualenv) and ignore DJANGO_SETTINGS_MODULE"),
     )
     help = ("Copy static media files from apps and other locations in a "
             "single location.")

--- a/staticfiles/management/commands/build_static.py
+++ b/staticfiles/management/commands/build_static.py
@@ -46,11 +46,18 @@ class Command(OptionalAppCommand):
         make_option('--use-virtualenv', action='store_true',
             dest='use_virtualenv', default=False,
             help="Use all Django apps currently available on PYTHONPATH (from virtualenv) and ignore DJANGO_SETTINGS_MODULE"),
+        make_option('--static-root-target', action='store', type='string',
+            dest='static_root_target', default=False,
+            help="Override STATIC_ROOT and target a different folder"),
     )
     help = ("Copy static media files from apps and other locations in a "
             "single location.")
 
     def handle(self, *app_labels, **options):
+        if options.has_key('static_root_target'):
+            import staticfiles.settings
+            staticfiles.settings.ROOT = os.path.abspath(options.get('static_root_target'))
+
         ignore_patterns = options['ignore_patterns']
         if options['use_default_ignore_patterns']:
             ignore_patterns += ['CVS', '.*', '*~']


### PR DESCRIPTION
i often work on projects that have multiple settings (for admin, portal, api, ...) and a complete list of all apps with media/static files is a combination of all INSTALLED_APPS in all settings.
since i use virtualenv i know that all media/static apps are on PYTHONPATH and an option for build_static to use all modules available is useful for me.
please consider adding something like this to django-staticfiles.
