### PR TITLE
Command object has no object 'stdout'

### DIFF
--- a/staticfiles/management/commands/collectstatic.py
+++ b/staticfiles/management/commands/collectstatic.py
@@ -91,7 +91,7 @@ Type 'yes' to continue, or 'no' to cancel: """)
         actual_count = len(self.copied_files) + len(self.symlinked_files)
         unmodified_count = len(self.unmodified_files)
         if self.verbosity >= 1:
-            self.stdout.write(smart_str(u"\n%s static file%s %s to '%s'%s.\n"
+            sys.stdout.write(smart_str(u"\n%s static file%s %s to '%s'%s.\n"
                               % (actual_count, actual_count != 1 and 's' or '',
                                  symlink and 'symlinked' or 'copied',
                                  settings.STATIC_ROOT,
@@ -106,7 +106,7 @@ Type 'yes' to continue, or 'no' to cancel: """)
         if not msg.endswith("\n"):
             msg += "\n"
         if self.verbosity >= level:
-            self.stdout.write(msg)
+            sys.stdout.write(msg)
 
     def delete_file(self, path, prefixed_path, source_storage, **options):
         # Whether we are in symlink mode


### PR DESCRIPTION
Seeing the following error with django 1.2 and 1.2.1, python 2.6.1.  http://pastebin.com/WdhzH3wF

Apparently self.stdout doesn't exist when using BaseCommand or its' children.  It's just a simple printing issue, but was preventing me from deploying to gondor and using the staticfiles app completely.  Seems like a simple fix.  Was I using incompatible versions?

Also, I've deployed to gondor (http://gondor.io) and run locally successfully with this change.
