### PR TITLE
Improved behavior of CachedFilesMixin with non-local storage backends

### DIFF
--- a/staticfiles/management/commands/collectstatic.py
+++ b/staticfiles/management/commands/collectstatic.py
@@ -128,11 +128,8 @@ Type 'yes' to continue, or 'no' to cancel: """
         # Here we check if the storage backend has a post_process
         # method and pass it the list of modified files.
         if self.post_process and hasattr(self.storage, 'post_process'):
-            post_processed = self.storage.post_process(found_files, **options)
-            for path in post_processed:
+            for path in self.storage.post_process(found_files, **options):
                 self.log(u"Post-processed '%s'" % path, level=1)
-        else:
-            post_processed = []
 
         modified_files = self.copied_files + self.symlinked_files
         actual_count = len(modified_files)

--- a/staticfiles/storage.py
+++ b/staticfiles/storage.py
@@ -217,10 +217,9 @@ class CachedFilesMixin(object):
         """
         Post process the given list of files (called from collectstatic).
         """
-        processed_files = []
         # don't even dare to process the files if we're in dry run mode
         if dry_run:
-            return processed_files
+            return
 
         # delete cache of all handled paths
         self.cache.delete_many([self.cache_key(path) for path in paths])
@@ -254,12 +253,11 @@ class CachedFilesMixin(object):
                 content_file = ContentFile(smart_str(content))
                 saved_name = self._save(hashed_name, content_file)
                 hashed_name = force_unicode(saved_name.replace('\\', '/'))
-                processed_files.append(hashed_name)
 
                 # and then set the cache accordingly
                 self.cache.set(self.cache_key(name), hashed_name)
 
-        return processed_files
+                yield hashed_name
 
 
 class CachedStaticFilesStorage(CachedFilesMixin, StaticFilesStorage):

--- a/staticfiles/storage.py
+++ b/staticfiles/storage.py
@@ -3,6 +3,12 @@ import os
 import posixpath
 import re
 import warnings
+
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from StringIO import StringIO
+
 from datetime import datetime
 from urllib import unquote
 from urlparse import urlsplit, urlunsplit, urldefrag
@@ -131,7 +137,11 @@ class CachedFilesMixin(object):
         root, ext = os.path.splitext(filename)
         # Get the MD5 hash of the file
         md5 = md5_constructor()
-        for chunk in content.chunks():
+        readmethod = {
+            True: getattr(content, 'chunks', None),
+            False: getattr(content, 'read'),
+        }[hasattr(content, 'chunks')]
+        for chunk in readmethod():
             md5.update(chunk)
         md5sum = md5.hexdigest()[:12]
         hashed_name = os.path.join(path, u"%s.%s%s" %
@@ -222,34 +232,41 @@ class CachedFilesMixin(object):
             return
 
         # delete cache of all handled paths
-        self.cache.delete_many([self.cache_key(path) for path in paths])
+        self.cache.delete_many([self.cache_key(path) for path in paths.keys()])
 
-        # only try processing the files we have patterns for
+        # only try munging the files we have patterns for
         matches = lambda path: matches_patterns(path, self._patterns.keys())
-        processing_paths = [path for path in paths if matches(path)]
+        munge_paths = [path for path in paths.keys() if matches(path)]
 
         # then sort the files by the directory level
         path_level = lambda name: len(name.split(os.sep))
-        for name in sorted(paths, key=path_level, reverse=True):
+        for name in sorted(paths.keys(), key=path_level, reverse=True):
 
-            # first get a hashed name for the given file
-            hashed_name = self.hashed_name(name)
+            # get the original, local file
+            # not the copied-but-unprocessed file, which might be somewhere
+            # far away, like S3, and thus slow to read.
+            storage, raw_path = paths[name]
+            with storage.open(raw_path) as original_file:
 
-            with self.open(name) as original_file:
-                # then get the original's file content
                 content = original_file.read()
 
-                # to apply each replacement pattern on the content
-                if name in processing_paths:
+                # munge files if they're mungable
+                if name in munge_paths:
+                    # content = original_file.read()
                     converter = self.url_converter(name)
                     for patterns in self._patterns.values():
                         for pattern in patterns:
                             content = pattern.sub(converter, content)
 
-                # then save the processed result
-                if self.exists(hashed_name):
-                    self.delete(hashed_name)
+                # generate the hash
+                hashed_name = self.hashed_name(name, StringIO(content))
 
+                if self.exists(hashed_name):
+                    self.cache.set(self.cache_key(name), hashed_name)
+                    yield hashed_name, False
+                    continue
+
+                # then save the processed result
                 content_file = ContentFile(smart_str(content))
                 saved_name = self._save(hashed_name, content_file)
                 hashed_name = force_unicode(saved_name.replace('\\', '/'))
@@ -257,7 +274,7 @@ class CachedFilesMixin(object):
                 # and then set the cache accordingly
                 self.cache.set(self.cache_key(name), hashed_name)
 
-                yield hashed_name
+                yield hashed_name, True
 
 
 class CachedStaticFilesStorage(CachedFilesMixin, StaticFilesStorage):


### PR DESCRIPTION
When using a network storage backend (like S3), post_process can take a long
time, during which no feedback is presented when running collectstatic.

Improvement is about two things:
- providing better feedback about what is going on during post-processing
- eliminating the need to read file contents out of remote storage for comparison
