### PR TITLE
Added STATICFILES_IGNORE_PATTERNS setting.

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -89,6 +89,26 @@ This would allow you to refer to the local file
 
     <a href="{{ STATIC_URL }}downloads/polls_20101022.tar.gz">
 
+``STATICFILES_IGNORE_PATTERNS``
+-------------------------------
+
+:Default: ``[]``
+
+This setting defines patterns to be ignored by the :ref:`collectstatic`
+management command.
+
+This should be set to a list or tuple of strings that contain file or
+directory names and may include an absolute file system path or a path
+relative to STATIC_ROOT_, e.g.::
+
+    STATICFILES_IGNORE_PATTERNS = (
+        "*.txt",
+        "tests",
+        "css/*.old",
+        "/opt/webfiles/common/*.txt",
+        "/opt/webfiles/common/temp",
+    )
+
 ``STATICFILES_EXCLUDED_APPS``
 -----------------------------
 

--- a/staticfiles/conf.py
+++ b/staticfiles/conf.py
@@ -15,6 +15,8 @@ class StaticFilesConf(AppConf):
     # A tuple of two-tuples with a name and the path of additional directories
     # which hold static files and should be taken into account
     DIRS = ()
+    # Patterns that should be ignored by collectstatic
+    IGNORE_PATTERNS = ()
     # Apps that shouldn't be taken into account when collecting app media
     EXCLUDED_APPS = ()
     # Destination storage

--- a/staticfiles/management/commands/collectstatic.py
+++ b/staticfiles/management/commands/collectstatic.py
@@ -9,6 +9,7 @@ from django.core.management.base import CommandError, NoArgsCommand
 from django.utils.encoding import smart_str, smart_unicode
 
 from staticfiles import finders, storage
+from staticfiles.conf import settings
 
 
 class Command(NoArgsCommand):
@@ -64,6 +65,7 @@ class Command(NoArgsCommand):
         self.clear = options['clear']
         self.dry_run = options['dry_run']
         ignore_patterns = options['ignore_patterns']
+        ignore_patterns.extend(settings.STATICFILES_IGNORE_PATTERNS)
         if options['use_default_ignore_patterns']:
             ignore_patterns += ['CVS', '.*', '*~']
         self.ignore_patterns = list(set(ignore_patterns))

--- a/staticfiles/test_settings.py
+++ b/staticfiles/test_settings.py
@@ -30,6 +30,14 @@ STATICFILES_DIRS = (
     ('prefix', os.path.join(TEST_ROOT, 'project', 'prefixed')),
 )
 
+STATICFILES_IGNORE_PATTERNS = (
+    '*.ignoreme4',
+    os.path.join('test', '*.ignoreme5'),
+    os.path.join(TEST_ROOT, 'project', 'documents', 'test', '*.ignoreme6'),
+    os.path.join('prefix', '*.ignoreme7'),
+    os.path.join(TEST_ROOT, 'project', 'documents', 'ignored'),
+)
+
 STATICFILES_EXCLUDED_APPS = (
     'staticfiles.tests.apps.skip',
 )

--- a/staticfiles/tests/apps/test/static/test/test_absolute.ignoreme3
+++ b/staticfiles/tests/apps/test/static/test/test_absolute.ignoreme3
@@ -1,0 +1,1 @@
+This file should be ignored.

--- a/staticfiles/tests/apps/test/static/test/test_relative.ignoreme2
+++ b/staticfiles/tests/apps/test/static/test/test_relative.ignoreme2
@@ -1,0 +1,1 @@
+This file should be ignored.

--- a/staticfiles/tests/project/documents/ignored/test_directory.txt
+++ b/staticfiles/tests/project/documents/ignored/test_directory.txt
@@ -1,0 +1,1 @@
+Is this file ignored?

--- a/staticfiles/tests/project/documents/test/test.ignoreme4
+++ b/staticfiles/tests/project/documents/test/test.ignoreme4
@@ -1,0 +1,1 @@
+This file should be ignored.

--- a/staticfiles/tests/project/documents/test/test_absolute.ignoreme6
+++ b/staticfiles/tests/project/documents/test/test_absolute.ignoreme6
@@ -1,0 +1,1 @@
+This file should be ignored.

--- a/staticfiles/tests/project/documents/test/test_relative.ignoreme5
+++ b/staticfiles/tests/project/documents/test/test_relative.ignoreme5
@@ -1,0 +1,1 @@
+This file should be ignored.

--- a/staticfiles/tests/project/prefixed/test.ignoreme7
+++ b/staticfiles/tests/project/prefixed/test.ignoreme7
@@ -1,0 +1,1 @@
+This file should be ignored.

--- a/staticfiles/tests/tests.py
+++ b/staticfiles/tests/tests.py
@@ -131,8 +131,11 @@ class BaseCollectionTestCase(BaseStaticFilesTestCase, unittest2.TestCase):
         super(BaseCollectionTestCase, self).tearDown()
 
     def run_collectstatic(self, **kwargs):
+        ignore_patterns = [
+            '*.ignoreme', os.path.join('test', '*.ignoreme2'), os.path.join(
+                TEST_ROOT, 'apps', 'test', 'static', 'test', '*.ignoreme3')]
         call_command('collectstatic', interactive=False, verbosity='0',
-                     ignore_patterns=['*.ignoreme'], **kwargs)
+                     ignore_patterns=ignore_patterns, **kwargs)
 
     def _get_file(self, filepath):
         assert filepath, 'filepath is empty.'
@@ -239,6 +242,8 @@ class TestCollection(CollectionTestCase, TestDefaults):
         Test that -i patterns are ignored.
         """
         self.assertFileNotFound('test/test.ignoreme')
+        self.assertFileNotFound('test/test_relative.ignoreme2')
+        self.assertFileNotFound('test/test_absolute.ignoreme3')
 
     def test_common_ignore_patterns(self):
         """
@@ -247,6 +252,16 @@ class TestCollection(CollectionTestCase, TestDefaults):
         self.assertFileNotFound('test/.hidden')
         self.assertFileNotFound('test/backup~')
         self.assertFileNotFound('test/CVS')
+
+    def test_staticfiles_ignore_patterns(self):
+        """
+        Test that patterns in STATICFILES_IGNORE_PATTERNS are ignored.
+        """
+        self.assertFileNotFound('test/test.ignoreme4')
+        self.assertFileNotFound('test/test_relative.ignoreme5')
+        self.assertFileNotFound('test/test_absolute.ignoreme6')
+        self.assertFileNotFound('prefix/test.ignoreme7')
+        self.assertFileNotFound('ignored/test_directory.txt')
 
 
 class TestCollectionClear(CollectionTestCase):


### PR DESCRIPTION
Defines patterns to be ignored by the collectstatic management command.

See issue #21 for discussion.

(Recreated pull request because I needed to rename branch.)
