### PR TITLE
Make collectstatic for cached static files more "atomic".

### DIFF
--- a/staticfiles/storage.py
+++ b/staticfiles/storage.py
@@ -234,8 +234,8 @@ class CachedFilesMixin(object):
         if dry_run:
             return
 
-        # delete cache of all handled paths
-        self.cache.delete_many([self.cache_key(path) for path in paths])
+        # where to store the new paths
+        new_hashed_paths = {}
 
         # build a list of adjustable files
         matches = lambda path: matches_patterns(path, self._patterns.keys())
@@ -284,8 +284,10 @@ class CachedFilesMixin(object):
                         hashed_name = force_unicode(saved_name.replace('\\', '/'))
 
                 # and then set the cache accordingly
-                self.cache.set(self.cache_key(name), hashed_name)
+                new_hashed_paths[self.cache_key(name)] = hashed_name
                 yield name, hashed_name, processed
+
+        self.cache.set_many(new_hashed_paths)
 
 
 class CachedStaticFilesStorage(CachedFilesMixin, StaticFilesStorage):


### PR DESCRIPTION
The commit moves all cache set to the end of the post-processing phase
of the CachedStaticFilesStorage class. We do that by keeping a
dictionary of what needs to be stored to the cache and store that after
all static files have been post-processed. Additionally, existing cache
keys are never deleted; instead, we rely on the cache expiration to
remove not-recently-used keys.

This is convenient for deployments. Ususally, one first does a
collectstatic and then restarts his application servers. But since the
cache is (normally) shared with the currently running application
processes, any change to the static files will be immediately used for
existing requests. This results in having a previous codebase serving
newer static files, which might lead to issues.

The commit moves all cache handling to the end, so that the above window
of serving wrong versions of the static files is minimized. This has the
added benefit, that one can safely stop the collectstatic command in the
middle of the execution, without any impact on the existing application
processes (the old files are always there, anyway).
