### PR TITLE
Use get_internal_wsgi_application in Django 1.4

### DIFF
--- a/staticfiles/management/commands/runserver.py
+++ b/staticfiles/management/commands/runserver.py
@@ -4,8 +4,11 @@ import sys
 from optparse import make_option
 
 from django.conf import settings
-from django.core.handlers.wsgi import WSGIHandler
 from django.core.servers.basehttp import run, WSGIServerException
+try:
+    from django.core.servers.basehttp import get_internal_wsgi_application as WSGIHandler
+except ImportError:
+    from django.core.handlers.wsgi import WSGIHandler
 from django.core.management.base import BaseCommand, CommandError
 
 from staticfiles.handlers import StaticFilesHandler

--- a/staticfiles/management/commands/runserver.py
+++ b/staticfiles/management/commands/runserver.py
@@ -8,7 +8,7 @@ from django.core.servers.basehttp import run, WSGIServerException
 try:
     from django.core.servers.basehttp import get_internal_wsgi_application as WSGIHandler
 except ImportError:
-    from django.core.handlers.wsgi import WSGIHandler
+    from django.core.handlers.wsgi import WSGIHandler  # NOQA
 from django.core.management.base import BaseCommand, CommandError
 
 from staticfiles.handlers import StaticFilesHandler


### PR DESCRIPTION
Mimic the runserver command that ships in Django 1.4 and up more
closely. By default, that command gets the WSGI handler by calling
`get_internal_wsgi_application()`. Without this change, the `runserver`
command ignores the `WSGI_APPLICATION` setting in Django 1.4.
By ignoring the setting, the runserver command will not apply any
WSGI middleware in the wsgi.py file.

If `get_internal_wsgi_application` is not available for import, revert back
to the previous `WSGIHandler()` function.
