### PR TITLE
Update to django 1.5

### DIFF
--- a/staticfiles/storage.py
+++ b/staticfiles/storage.py
@@ -19,7 +19,7 @@ from django.utils.encoding import force_unicode, smart_str
 from django.utils.datastructures import SortedDict
 from django.utils.functional import LazyObject
 from django.utils.importlib import import_module
-from django.utils.hashcompat import md5_constructor
+from hashlib import md5 as md5_constructor
 
 from staticfiles.utils import matches_patterns
 

--- a/staticfiles/tests/urls/default.py
+++ b/staticfiles/tests/urls/default.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *  # noqa
+from django.conf.urls import *  # noqa
 
 urlpatterns = patterns('',
     url(r'^static/(?P<path>.*)$', 'staticfiles.views.serve'),

--- a/staticfiles/tests/urls/helper.py
+++ b/staticfiles/tests/urls/helper.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *  # noqa
+from django.conf.urls import *  # noqa
 from staticfiles.urls import staticfiles_urlpatterns
 
 urlpatterns = staticfiles_urlpatterns()

--- a/staticfiles/urls.py
+++ b/staticfiles/urls.py
@@ -1,5 +1,5 @@
 import re
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.core.exceptions import ImproperlyConfigured
 
 from staticfiles.conf import settings


### PR DESCRIPTION
Avoid deprecation warnings: 
- `django.conf.urls.defaults` is deprecated
- `django.utils.hashcompat` is deprecated
